### PR TITLE
Improved on the heap safety when creating events

### DIFF
--- a/src/addr.c
+++ b/src/addr.c
@@ -47,14 +47,9 @@ void destroy_addr(addr_handle_t *handle) {
     free(handle);
 }
 
-static char *format_payload(const addr_info_t *addr) {
-    char *payload = malloc((size_t) MAX_PAYLOAD_SIZE);
-
-    snprintf(payload, MAX_PAYLOAD_SIZE - 1,
-             "time=%lu,idx=%d,addr=%s",
-             time(NULL), addr->index, addr->addr.addr);
-
-    return payload;
+static inline event_t *create_addr_event(event_type_t event_type, addr_info_t *ptr) {
+    return create_event(event_type, "time=%lu,idx=%d,addr=%s",
+                        time(NULL), ptr->index, ptr->addr.addr);
 }
 
 static event_t *add_addr(addr_handle_t *handle, uint32_t index,
@@ -77,7 +72,7 @@ static event_t *add_addr(addr_handle_t *handle, uint32_t index,
         // Found it...
         log_debug("updating existing address (%s @ %d)", addr, index);
 
-        return create_event(ADDRESS_UPDATE, format_payload(ptr));
+        return create_addr_event(ADDRESS_UPDATE, ptr);
     }
 
     assert(ptr == NULL);
@@ -92,7 +87,7 @@ static event_t *add_addr(addr_handle_t *handle, uint32_t index,
 
     log_debug("added new address (%s @ %d)", addr, index);
 
-    return create_event(ADDRESS_ADD, format_payload(ptr));
+    return create_addr_event(ADDRESS_ADD, ptr);
 }
 
 static event_t *del_addr(addr_handle_t *handle, uint32_t index,
@@ -130,7 +125,7 @@ static event_t *del_addr(addr_handle_t *handle, uint32_t index,
 
     log_debug("deleted address (%s @ %d)", addr, index);
 
-    event_t *event = create_event(ADDRESS_DELETE, format_payload(ptr));
+    event_t *event = create_addr_event(ADDRESS_DELETE, ptr);
 
     free(ptr);
 

--- a/src/config.c
+++ b/src/config.c
@@ -125,11 +125,13 @@ config_t *read_config(const char *file) {
         goto cleanup; \
     } while (0);
 
+    FILE *fh = NULL;
+
     if (!yaml_parser_initialize(&parser)) {
         PARSE_ERROR("failed to initialize parser!");
     }
 
-    FILE *fh = fopen(file, "r");
+    fh = fopen(file, "r");
     if (fh == NULL) {
         PARSE_ERROR("failed to open configuration file: %s", file);
     }

--- a/src/event.c
+++ b/src/event.c
@@ -1,6 +1,9 @@
+#include <stdio.h>
+#include <stdarg.h>
 #include <stdlib.h>
 
 #include "event.h"
+#include "logging.h"
 #include "netmon.h"
 
 #define LINK "link/"
@@ -27,10 +30,52 @@ const char *event_topic_name(event_type_t event_type) {
     return event_topic_names[event_type];
 }
 
-event_t *create_event(event_type_t event_type, char *data) {
+#define INITIAL_BUFFER_SIZE 256
+
+event_t *create_event(event_type_t event_type, const char *fmt, ...) {
+    va_list ap;
+    char *payload = NULL;
+    size_t bufsize = INITIAL_BUFFER_SIZE;
+
+    do {
+        payload = malloc(bufsize*sizeof(char));
+        if (payload == NULL) {
+            log_error("failed to allocate memory for event payload buffer!");
+            return NULL;
+        }
+
+        va_start(ap, fmt);
+
+        size_t written = (size_t) vsnprintf(payload, bufsize, fmt, ap);
+
+        va_end(ap);
+
+        if (written < 0) {
+            // generic failure...
+            log_error("vnsprintf failed for event payload: %m");
+            free(payload);
+            return NULL;
+        } else if (written >= bufsize) {
+            // buffer was not large enough...
+            log_debug("did not allocate enough room for event payload: need %d extra bytes...",
+                      (written - bufsize));
+
+            bufsize = written + 1;
+
+            free(payload);
+            payload = NULL;
+        }
+    } while (payload == NULL);
+
     event_t *result = malloc(sizeof(event_t));
+    if (result == NULL) {
+        log_error("failed to allocate memory for event!");
+        return NULL;
+    }
+
     result->event_type = event_type;
-    result->data = data;
+    result->data = payload;
+
     return result;
 }
 

--- a/src/inc/addr_common.h
+++ b/src/inc/addr_common.h
@@ -13,8 +13,8 @@
 #define MAC_LEN 6
 
 struct addr {
-	uint8_t family;
-	char addr[INET6_ADDRSTRLEN];
+    uint8_t family;
+    char addr[INET6_ADDRSTRLEN];
 };
 
 #endif /* ADDR_COMMON_H_ */

--- a/src/inc/event.h
+++ b/src/inc/event.h
@@ -30,7 +30,7 @@ typedef struct event {
 
 const char *event_topic_name(event_type_t event_type);
 
-event_t *create_event(event_type_t event_type, char *data);
+event_t *create_event(event_type_t event_type, const char *fmt, ...);
 
 void free_event(event_t *event);
 

--- a/src/inc/logging.h
+++ b/src/inc/logging.h
@@ -8,6 +8,8 @@
 #ifndef LOGGING_H_
 #define LOGGING_H_
 
+#include <stdbool.h>
+
 void init_logging(bool debug, bool foreground);
 void destroy_logging(void);
 

--- a/src/inc/mqtt.h
+++ b/src/inc/mqtt.h
@@ -13,8 +13,6 @@
 #include "config.h"
 #include "event.h"
 
-#define MAX_PAYLOAD_SIZE 256
-
 #define MAX_TOPIC_NAME_LENGTH 256
 
 typedef struct mqtt_handle mqtt_handle_t;

--- a/src/util.c
+++ b/src/util.c
@@ -12,12 +12,17 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "addr_common.h"
 #include "logging.h"
 #include "util.h"
 
+// 6*2 digits + 5*colon + '\0' = 18
+#define MAC_STR_LEN 18
+
 char *format_mac(const uint8_t lladdr[MAC_LEN]) {
-    static char buf[18];
-    snprintf(buf, sizeof(buf), "%02x:%02x:%02x:%02x:%02x:%02x",
+    static char buf[MAC_STR_LEN];
+    // no need to check return value here, we're using a static buffer
+    snprintf(buf, MAC_STR_LEN, "%02x:%02x:%02x:%02x:%02x:%02x",
              lladdr[0], lladdr[1], lladdr[2],
              lladdr[3], lladdr[4], lladdr[5]);
     return buf;


### PR DESCRIPTION
Moved the formatting of payloads to the `create_event` method to allow us to perform additional sanity checks. This avoids possible heap pollution. With the help of some additional inline functions the calling pattern for event creation is simplified a lot.

Also fixed a couple of warnings that Clang found wrt potential use of undefined variables.