### PR TITLE
Implemented support for OUI lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 exp/
 netmon.cfg
 netmon.yml
+netmon_oui.list
 *.code-workspace
 valgrind-out.txt
 .vscode/ipch/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -7,7 +7,10 @@
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",
-            "cStandard": "c11"
+            "cStandard": "c11",
+            "browse": {
+                "limitSymbolsToIncludedHeaders": true
+            }
         }
     ],
     "version": 4

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The default configuration is defined as:
 ```yaml   
 # netmon configuration
 
+oui:
+   # the path to the vendor lookup file. See
+   # https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=manuf;hb=HEAD
+   # for a complete listing. If omitted, no vendor lookups will be performed.
+   file: /etc/netmon_oui.list
+
 daemon:
    # Denotes the user the daemon process will run under.
    # Defaults to "nobody".
@@ -103,9 +109,10 @@ for example:
 {
    "last_seen": 1558955353,
    "addr": "192.168.1.99",
-   "mac": "af:b8:62:f5:38:8c",
+   "mac": "ac:bc:32:f5:38:8c",
+   "vendor": "Apple Inc.",
    "src_iface": "eth0",
-   "src_mac": "10:67:ec:22:af:4e",
+   "src_mac": "10:66:82:22:af:4e",
    "src_vlan": 2,
    "src_ip": "192.168.1.1"
 }
@@ -122,6 +129,7 @@ The fields in the JSON object have the following semantics:
 | last_seen | the Unix epoch timestamp on which the neighbour was last seen by netmon    |
 | addr      | the IP address of the neighbour                                            |
 | mac       | the MAC address of the neighbour                                           |
+| vendor    | the name of the OUI / vendor of the neighbour                              |
 | src       | the information about the source interface on which the neighbour was seen |
 | src_iface | the source network interface                                               |
 | src_mac   | the source MAC address                                                     |
@@ -138,13 +146,17 @@ Netmon requires the following build dependencies:
 - libmosquitto (1.5.5 or later);
 - libyaml (0.2.1 or later).
 
-In addition, you a libc implementation that supports PTHREADS, such as glibc or
-musl.
+If you want to run the unit tests, you additionally need:
+
+- cUnit (2.1 or later).
 
 Since netlink functionality is used, netmon will only compile under Linux.
 
 Compilation is done by running `make all`. All build artifacts are placed in 
-the `build` directory.
+the `build` directory.  
+To compile the unit tests, add `TEST=1` to your make command, for example:
+`make TEST=1 clean all`. The result will be a `netmon_test` binary that will
+run all of the tests.
 
 ### Finding memory leaks
 

--- a/src/config.c
+++ b/src/config.c
@@ -22,6 +22,7 @@
 typedef enum config_block {
     ROOT = 0,
     DAEMON,
+    OUI,
     MQTT,
     MQTT_AUTH,
     MQTT_TLS,
@@ -70,6 +71,9 @@ static int init_priv_user(config_t *cfg) {
 }
 
 static int init_config(config_t *cfg) {
+    cfg->oui_file = NULL;
+    cfg->vendor_lookup = false;
+
     cfg->client_id = NULL;
     cfg->host = NULL;
     cfg->port = 0;
@@ -180,6 +184,8 @@ config_t *read_config(const char *file) {
 
             if (VALUE_IN_CONTEXT("daemon", ROOT)) {
                 cblock = DAEMON;
+            } else if (VALUE_IN_CONTEXT("oui", ROOT)) {
+                cblock = OUI;
             } else if (VALUE_IN_CONTEXT("mqtt", ROOT)) {
                 cblock = MQTT;
             } else if (VALUE_IN_CONTEXT("auth", MQTT)) {
@@ -206,6 +212,9 @@ config_t *read_config(const char *file) {
                     } else {
                         PARSE_ERROR("invalid configuriation file: unknown group '%s'", val);
                     }
+                } else if (KEY_IN_CONTEXT("file", OUI)) {
+                    cfg->oui_file = safe_strdup(val);
+                    cfg->vendor_lookup = true;
                 } else if (KEY_IN_CONTEXT("client_id", MQTT)) {
                     cfg->client_id = safe_strdup(val);
                 } else if (KEY_IN_CONTEXT("host", MQTT)) {
@@ -325,6 +334,8 @@ void free_config(config_t *config) {
     if (!config) {
         return;
     }
+
+    free(config->oui_file);
 
     free(config->client_id);
     free(config->host);

--- a/src/event.c
+++ b/src/event.c
@@ -39,13 +39,17 @@ const char *event_topic_name(event_type_t event_type) {
       offset += ((size_t)status);                                              \
   } while (0)
 
-event_t *create_event(event_type_t event_type, const addr_t *src_addr, const link_t *src_link, const neigh_t *neigh) {
+event_t *create_event(event_type_t event_type, const addr_t *src_addr, const link_t *src_link, const neigh_t *neigh, const char *vendor) {
     size_t offset = 0;
     size_t buffer_size = INITIAL_BUFFER_SIZE;
     char *buffer = malloc(buffer_size * sizeof(char));
 
     BUFFER_ADD("{\"last_seen\":%lu,\"addr\":\"%s\",\"mac\":\"%s\"",
                time(NULL), neigh->dst_addr.addr, format_mac(neigh->ll_addr));
+
+    if (vendor) {
+        BUFFER_ADD(",\"vendor\":\"%s\"", vendor);
+    }
 
     if (src_link) {
         BUFFER_ADD(",\"src_iface\":\"%s\",\"src_mac\":\"%s\"",

--- a/src/inc/addr.h
+++ b/src/inc/addr.h
@@ -7,7 +7,7 @@
 #ifndef ADDR_H_
 #define ADDR_H_
 
-#include "addr_common.h"
+#include <libmnl/libmnl.h>
 
 typedef struct addr_handle addr_handle_t;
 

--- a/src/inc/config.h
+++ b/src/inc/config.h
@@ -15,6 +15,9 @@ typedef struct config {
     uid_t priv_user;
     gid_t priv_group;
 
+    char *oui_file;
+    bool vendor_lookup;
+
     char *client_id;
     char *host;
     uint16_t port;

--- a/src/inc/event.h
+++ b/src/inc/event.h
@@ -23,7 +23,7 @@ typedef struct event {
 
 const char *event_topic_name(event_type_t event_type);
 
-event_t *create_event(event_type_t event_type, const addr_t *src_addr, const link_t *src_link, const neigh_t *neigh);
+event_t *create_event(event_type_t event_type, const addr_t *src_addr, const link_t *src_link, const neigh_t *neigh, const char *vendor);
 
 void free_event(event_t *event);
 

--- a/src/inc/link.h
+++ b/src/inc/link.h
@@ -7,7 +7,7 @@
 #ifndef LINK_H_
 #define LINK_H_
 
-#include "addr_common.h"
+#include <libmnl/libmnl.h>
 
 typedef struct link_handle link_handle_t;
 

--- a/src/inc/neigh.h
+++ b/src/inc/neigh.h
@@ -7,6 +7,8 @@
 #ifndef NEIGH_H_
 #define NEIGH_H_
 
+#include <libmnl/libmnl.h>
+
 typedef struct neigh_handle neigh_handle_t;
 
 neigh_handle_t *init_neigh(void);

--- a/src/inc/netlink.h
+++ b/src/inc/netlink.h
@@ -8,6 +8,9 @@
 #define NETLINK_H_
 
 #include "event.h"
+#include "addr.h"
+#include "link.h"
+#include "neigh.h"
 
 /**
  * Defines the handle that is to be used to talk to the Netlink routines.

--- a/src/inc/netmon.h
+++ b/src/inc/netmon.h
@@ -8,7 +8,7 @@
 #define NETMON_H_
 
 #define PNAME "netmon"
-#define VERSION "0.10.3"
+#define VERSION "0.11.0"
 
 #define PID_FILE "/run/" PNAME ".pid"
 #define CONF_FILE "/etc/" PNAME ".cfg"

--- a/src/inc/oui.h
+++ b/src/inc/oui.h
@@ -1,0 +1,65 @@
+/*
+ * netmon - simple Linux network monitor
+ *
+ * Copyright: (C) 2019 jawi
+ *   License: Apache License 2.0
+ */
+#ifndef OUI_H_
+#define OUI_H_
+
+#include <stddef.h>
+
+#define MAX_NAME_LEN  64
+
+typedef struct oui_info oui_info_t;
+
+typedef struct oui_list oui_list_t;
+
+typedef struct oui_info {
+    uint64_t oui;
+    uint64_t mask;
+    char manuf[MAX_NAME_LEN];
+    struct oui_info *next;
+} oui_info_t;
+
+extern oui_list_t *oui_list;
+
+/**
+ * Parses the OUI entries from the given file.
+ *
+ * @param oui_file the source file to read the entries from.
+ * @return the list with OUI entries, or NULL in case the parsing failed.
+ */
+oui_list_t *parse_oui_list(char *src_file);
+
+/**
+ * Releases all allocated memory for the given OUI list.
+ *
+ * @param list the OUI list to free.
+ * @return always NULL.
+ */
+oui_list_t *free_oui_list(oui_list_t *list);
+
+/**
+ * Finds the OUI vendor information for a given OUI-value.
+ *
+ * @param list the OUI list to search in;
+ * @param oui the OUI-value to search for.
+ * @return the vendor that owns the given OUI, or NULL in case no vendor
+ *         information could be found.
+ */
+const char *find_oui_vendor(oui_list_t *list, uint64_t oui);
+
+/**
+ * Finds a OUI entry in a given list of OUI entries, searching for most
+ * specific MAC addresses first, then for vendor-specific blocks and lastly in
+ * the general manufacturers table.
+ *
+ * @param list the OUI list to search in, cannot be NULL;
+ * @param oui the OUI-value to search for.
+ * @return the OUI information, or NULL in case no entry exists that matches
+ *         the given OUI-value.
+ */
+oui_info_t *find_oui(oui_list_t *list, uint64_t oui);
+
+#endif /* OUI_H_ */

--- a/src/inc/util.h
+++ b/src/inc/util.h
@@ -11,9 +11,26 @@
 
 #include "addr_common.h"
 
+#define ERR_UNKNOWN 1
+#define ERR_PIPE 10
+#define ERR_FORK 11
+#define ERR_PIPE_READ 12
+#define ERR_SETSID 20
+#define ERR_DAEMONIZE 21
+#define ERR_DEV_NULL 22
+#define ERR_PID_FILE 23
+#define ERR_CONFIG 24
+#define ERR_CHDIR 25
+#define ERR_DROP_PRIVS 26
+
 char *format_mac(const uint8_t lladdr[MAC_LEN]);
 
+uint64_t convert_to_oui(const uint8_t lladdr[MAC_LEN]);
+
 int drop_privileges(uid_t uid, gid_t gid);
+
 int write_pidfile(const char *pidfile, uid_t uid, gid_t gid);
+
+int daemonize(const char *pid_file, uid_t uid, gid_t gid);
 
 #endif /* UTIL_H_ */

--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -130,6 +130,7 @@ static int internal_reconnect_mqtt(mqtt_handle_t *handle) {
 }
 
 static void my_connect_cb(struct mosquitto *mosq, void *user_data, int result) {
+    (void)mosq;
     mqtt_handle_t *handle = (mqtt_handle_t *)user_data;
 
     if (!result) {
@@ -142,6 +143,7 @@ static void my_connect_cb(struct mosquitto *mosq, void *user_data, int result) {
 }
 
 static void my_disconnect_cb(struct mosquitto *mosq, void *user_data, int result) {
+    (void)mosq;
     mqtt_handle_t *handle = (mqtt_handle_t *)user_data;
 
     if (handle->conn_state != DISCONNECTED) {
@@ -151,6 +153,9 @@ static void my_disconnect_cb(struct mosquitto *mosq, void *user_data, int result
 }
 
 static void my_log_callback(struct mosquitto *mosq, void *user_data, int level, const char *msg) {
+    (void)mosq;
+    (void)user_data;
+    (void)level;
     log_debug(msg);
 }
 

--- a/src/netlink.c
+++ b/src/netlink.c
@@ -17,12 +17,11 @@
 #include <linux/if_link.h>
 #include <linux/rtnetlink.h>
 
-#include "addr.h"
 #include "config.h"
-#include "link.h"
 #include "logging.h"
-#include "neigh.h"
 #include "netlink.h"
+#include "oui.h"
+#include "util.h"
 
 struct netlink_handle {
     addr_handle_t *addr;
@@ -76,7 +75,13 @@ static int netlink_data_cb(const struct nlmsghdr *nlh, void *data) {
             addr_t *addr = get_addr(handle->addr, neigh->index);
             link_t *link = get_link(handle->link, neigh->index);
 
-            event_t *event = create_event(NEIGHBOUR_UPDATE, addr, link, neigh);
+            const char *vendor = NULL;
+            if (oui_list) {
+                uint64_t oui = convert_to_oui(neigh->ll_addr);
+                vendor = find_oui_vendor(oui_list, oui);
+            }
+
+            event_t *event = create_event(NEIGHBOUR_UPDATE, addr, link, neigh, vendor);
 
             if (event) {
                 (handle->callback)(event);

--- a/src/oui.c
+++ b/src/oui.c
@@ -1,0 +1,348 @@
+/*
+ * netmon - simple Linux network monitor
+ *
+ * Copyright: (C) 2019 jawi
+ *   License: Apache License 2.0
+ */
+
+#define _GNU_SOURCE
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "logging.h"
+#include "oui.h"
+#include "util.h"
+
+#define OUI_MASK      0xffffffffffffull
+
+struct oui_list {
+    oui_info_t *manufacturers; // mask == 0
+    oui_info_t *addr; // mask > 0 && mask < 48
+    oui_info_t *macs; // mask == 48
+};
+
+static uint8_t digit(char ch) {
+    if (ch >= '0' && ch <= '9') {
+        return (uint8_t) (ch - '0');
+    }
+    assert(0);
+}
+
+static bool iseol(char ch) {
+    return (ch == '#' || ch == '\r' || ch == '\n');
+}
+
+static uint8_t xdigit(char ch) {
+    if (ch >= '0' && ch <= '9') {
+        return (uint8_t) (ch - '0');
+    }
+    if (ch >= 'A' && ch <= 'F') {
+        return (uint8_t) (10 + (ch - 'A'));
+    }
+    if (ch >= 'a' && ch <= 'f') {
+        return (uint8_t) (10 + (ch - 'a'));
+    }
+    assert(0);
+}
+
+static inline size_t min(size_t a, size_t b) {
+    return (a < b) ? a : b;
+}
+
+/**
+ * Parses the entries from the given file.
+ *
+ * @param oui_file the source file to read the entries from.
+ * @return the OUI entries list.
+ */
+oui_list_t *parse_oui_list(char *oui_file) {
+    FILE *fh = fopen(oui_file, "r");
+    if (fh == NULL) {
+        log_warning("Unable to read file: %s: %m", oui_file);
+        return NULL;
+    }
+
+    char line[1024];
+    uint32_t line_no = 0;
+
+    oui_info_t *manufs = NULL, *manufs_ptr = NULL;
+    oui_info_t *addr = NULL, *addr_ptr = NULL;
+    oui_info_t *macs = NULL, *macs_ptr = NULL;
+
+    log_debug("Parsing OUI list '%s'...", oui_file);
+
+#define DO_WHILE(pred) while (s < sizeof(line) && line[s] != '\0' && pred(line[s])) { s++; }
+#define SKIP_WS DO_WHILE(isspace)
+#define APPEND_TO_LIST(l, e) \
+    if (l == NULL) { \
+        l = e; \
+        l ## _ptr = e; \
+    } else { \
+        l ## _ptr->next = e; \
+        l ## _ptr = l ## _ptr->next; \
+    }
+
+    while (fgets(line, sizeof(line)-1, fh) != NULL) {
+        line_no++;
+        size_t s = 0;
+
+        SKIP_WS;
+
+        if (line[s] == '#' || line[s] == '\0') {
+            // skip comments and empty lines...
+            continue;
+        }
+
+        uint64_t oui = 0, mask = 24;
+        bool manuf_entry = true;
+        int oui_len = 0;
+
+        while (!isspace(line[s])) {
+            char ch = line[s++];
+            if (ch == '/') {
+                // mask specifier, switch to parsing decimals...
+                manuf_entry = false;
+                mask = 0;
+            }
+            if (ch == ':' || ch == '-' || ch == '.' || (manuf_entry && !isxdigit(ch)) || (!manuf_entry && !isdigit(ch))) {
+                continue;
+            }
+            if (manuf_entry) {
+                oui = (oui << 4) | xdigit(ch);
+                oui_len++;
+            } else {
+                mask = (mask * 10) + digit(ch);
+            }
+        }
+
+        if (oui_len < 6 || oui_len > 12) {
+            // invalid OUI...
+            log_warning("Found invalid OUI data on line %d: %s\n", line_no, line);
+            continue;
+        }
+        if (mask <= 0 || mask > 48) {
+            // invalid mask value...
+            log_warning("Found invalid OUI mask on line %d: %s\n", line_no, line);
+            continue;
+        }
+
+        if (oui_len == 12 && manuf_entry && (mask == 24)) {
+            log_debug("Got a complete MAC address at line %d", line);
+            // We've got a full MAC address, presume it is a well-known MAC...
+            manuf_entry = false;
+            mask = 48;
+        }
+
+        SKIP_WS;
+
+        // short vendor name...
+        size_t sv_start = s;
+        DO_WHILE(!isspace);
+        size_t sv_len = min(MAX_NAME_LEN, (s - sv_start));
+
+        SKIP_WS;
+
+        // long vendor name...
+        size_t lv_start = s;
+        DO_WHILE(!iseol);
+        // trim trailing whitespaces...
+        while (s > lv_start && isspace(line[s])) {
+            s--;
+        }
+        size_t lv_len = min(MAX_NAME_LEN, (s - lv_start + 1));
+
+        // valid oui; extend it to a complete 48-bit address
+        oui_info_t *entry = malloc(sizeof(oui_info_t));
+
+        entry->oui = (oui << (8 * ((12 - oui_len) / 2)));
+        entry->mask = (-1ull << (48 - mask)) & OUI_MASK;
+        entry->next = NULL;
+
+        if (lv_len > 1) {
+            strncpy(entry->manuf, line + lv_start, lv_len);
+            entry->manuf[lv_len] = '\0';
+        } else if (sv_len > 0) {
+            strncpy(entry->manuf, line + sv_start, sv_len);
+            entry->manuf[sv_len] = '\0';
+        } else {
+            // no short or long vendor???
+            log_debug("No vendor information on line %d: %s", line_no, line);
+            entry->manuf[0] = 0;
+        }
+
+        // determine where to add this entry...
+        if (manuf_entry) {
+            APPEND_TO_LIST(manufs, entry);
+        } else if (mask > 24 && mask < 48) {
+            APPEND_TO_LIST(addr, entry);
+        } else {
+            APPEND_TO_LIST(macs, entry);
+        }
+    }
+
+    log_debug("OUI list parsing complete: processed %d lines...", line_no);
+
+    oui_list_t *result = malloc(sizeof(oui_list_t));
+    result->manufacturers = manufs;
+    result->addr = addr;
+    result->macs = macs;
+
+    fclose(fh);
+
+    return result;
+}
+
+static oui_info_t *free_entries(oui_info_t *entries) {
+    oui_info_t *ptr = entries;
+    while (ptr) {
+        oui_info_t *entry = ptr;
+        ptr = ptr->next;
+
+        free(entry);
+    }
+    return NULL;
+}
+
+oui_list_t *free_oui_list(oui_list_t *list) {
+    if (list) {
+        free_entries(list->manufacturers);
+        free_entries(list->addr);
+        free_entries(list->macs);
+        free(list);
+    }
+    return NULL;
+}
+
+/**
+ * Finds the middle element for a given linked list as denotes by the given start and end elements.
+ *
+ * @param start the start element, can be NULL in which case no middle element is found;
+ * @param end the last element, can be NULL for the end-of-list.
+ * @return the middle element, or NULL in case no middle element could be found.
+ */
+static oui_info_t *find_middle(oui_info_t *start, oui_info_t *end) {
+    if (!start) {
+        return NULL;
+    }
+
+    oui_info_t *slow = start;
+    oui_info_t *fast = start->next;
+
+    while (fast != end) {
+        fast = fast->next;
+        if (fast != end) {
+            slow = slow->next;
+            fast = fast->next;
+        }
+    }
+
+    return slow;
+}
+
+/**
+ * Compares the given OUI-value against a given entry, using the exact mask of the given entry.
+ *
+ * @param entry the OUI information to compare against;
+ * @param oui the OUI-value to compare.
+ * @return -1, 0 or 1 if the given OUI-value is more, equal or less than the given OUI information.
+ */
+static int compare_oui(oui_info_t *entry, uint64_t oui) {
+    uint64_t masked_oui = oui & entry->mask;
+    if (entry->oui > masked_oui) {
+        return 1;
+    } else if (entry->oui < masked_oui) {
+        return -1;
+    }
+    return 0;
+}
+
+/**
+ * Searches for a OUI that matches a given OUI value.
+ *
+ * @param entries the OUI entries to seach in;
+ * @param oui the OUI-value to search for.
+ * @return the found OUI information, or NULL in case no such entry exists.
+ */
+static oui_info_t *find_oui_info(oui_info_t *entries, uint64_t oui) {
+    oui_info_t *start = entries;
+    oui_info_t *middle = NULL;
+    oui_info_t *end = NULL;
+
+    do {
+        middle = find_middle(start, end);
+        if (!middle) {
+            // not found...
+            return NULL;
+        }
+
+        int r = compare_oui(middle, oui);
+        if (r == 0) {
+            // match...
+            return middle;
+        } else if (r < 0) {
+            start = middle->next;
+        } else {
+            end = middle;
+        }
+    }
+    while (!end || end != start);
+
+    // not found...
+    return NULL;
+}
+
+/**
+ * Finds a OUI entry in a given list of OUI entries, searching for most
+ * specific MAC addresses first, then for vendor-specific blocks and lastly in
+ * the general manufacturers table.
+ *
+ * @param list the OUI list to search in, cannot be NULL;
+ * @param oui the OUI-value to search for.
+ * @return the OUI information, or NULL in case no entry exists that matches
+ *         the given OUI-value.
+ */
+oui_info_t *find_oui(oui_list_t *list, uint64_t oui) {
+    oui_info_t *info;
+    if (!list) {
+        return NULL;
+    }
+
+    info = find_oui_info(list->macs, oui);
+    if (info) {
+        return info;
+    }
+
+    info = find_oui_info(list->addr, oui);
+    if (info) {
+        return info;
+    }
+
+    info = find_oui_info(list->manufacturers, oui);
+    if (info) {
+        return info;
+    }
+    return NULL;
+}
+
+/**
+ * Finds the OUI vendor information for a given OUI-value.
+ * 
+ * @param list the OUI list to search in;
+ * @param oui the OUI-value to search for.
+ * @return the vendor that owns the given OUI, or NULL in case no vendor information could be found.
+ */
+const char *find_oui_vendor(oui_list_t *list, uint64_t oui) {
+    oui_info_t *info = find_oui(list, oui);
+    if (info) {
+        return info->manuf;
+    }
+
+    return NULL;
+}

--- a/src/util.c
+++ b/src/util.c
@@ -4,12 +4,20 @@
  * Copyright: (C) 2019 jawi
  *   License: Apache License 2.0
  */
+
+#define _GNU_SOURCE
+
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
 
 #include "addr_common.h"
 #include "logging.h"
@@ -25,6 +33,15 @@ char *format_mac(const uint8_t lladdr[MAC_LEN]) {
              lladdr[0], lladdr[1], lladdr[2],
              lladdr[3], lladdr[4], lladdr[5]);
     return buf;
+}
+
+uint64_t convert_to_oui(const uint8_t lladdr[MAC_LEN]) {
+    return ((uint64_t)lladdr[0] << 40)
+           | ((uint64_t)lladdr[1] << 32)
+           | ((uint64_t)lladdr[2] << 24)
+           | ((uint64_t)lladdr[3] << 16)
+           | ((uint64_t)lladdr[4] << 8)
+           | ((uint64_t)lladdr[5]);
 }
 
 int drop_privileges(uid_t uid, gid_t gid) {
@@ -79,6 +96,104 @@ int write_pidfile(const char *pid_file, uid_t uid, gid_t gid) {
     dprintf(fd, "%d\n", getpid());
 
     close(fd);
+
+    return 0;
+}
+
+#define SAFE_SIGNAL(rc) \
+    int _rc = rc; \
+    if (write(err_pipe[1], &_rc, 1) != 1) { \
+        log_warning("failed to write single byte to pipe!"); \
+    } \
+    close(err_pipe[1]);
+
+#define SIGNAL_SUCCESS() \
+	do { \
+        SAFE_SIGNAL(0) \
+	} while (0)
+
+#define SIGNAL_FAILURE(rc) \
+	do { \
+        SAFE_SIGNAL(rc) \
+		exit(rc); \
+	} while (0)
+
+int daemonize(const char *pid_file, uid_t uid, gid_t gid) {
+    // create a anonymous pipe to communicate between daemon and our parent...
+    int err_pipe[2] = { 0 };
+    if (pipe(err_pipe) < 0) {
+        perror("pipe");
+        return ERR_PIPE;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return ERR_FORK;
+    } else if (pid > 0) {
+        // parent, wait until daemon is finished initializing...
+        close(err_pipe[1]);
+
+        int rc = 0;
+        if (read(err_pipe[0], &rc, 1) < 0) {
+            rc = ERR_PIPE_READ;
+        }
+        exit(rc);
+    } else { /* pid == 0 */
+        // first child continues here...
+        // NOTE: we can/should communicate our state to our parent in order for it to terminate!
+
+        // we only write to this pipe...
+        close(err_pipe[0]);
+
+        // create a new session...
+        pid = setsid();
+        if (pid < 0) {
+            SIGNAL_FAILURE(ERR_SETSID);
+        }
+
+        // fork again to ensure the daemon cannot take back the controlling tty...
+        pid = fork();
+        if (pid < 0) {
+            SIGNAL_FAILURE(ERR_DAEMONIZE);
+        } else if (pid > 0) {
+            // terminate first child...
+            exit(0);
+        } else { /* pid == 0 */
+            // actual daemon starts here...
+            int fd;
+
+            if ((fd = open("/dev/null", O_RDWR)) < 0) {
+                log_error("unable to open /dev/null: %s", strerror(errno));
+                SIGNAL_FAILURE(ERR_DEV_NULL);
+            } else {
+                dup2(fd, STDIN_FILENO);
+                dup2(fd, STDOUT_FILENO);
+                dup2(fd, STDERR_FILENO);
+                close(fd);
+            }
+
+            umask(0);
+
+            if (chdir("/") != 0) {
+                log_error("unable to change directory: %m");
+                SIGNAL_FAILURE(ERR_CHDIR);
+            }
+
+            if (write_pidfile(pid_file, uid, gid)) {
+                SIGNAL_FAILURE(ERR_PID_FILE);
+            }
+
+            if (drop_privileges(uid, gid)) {
+                SIGNAL_FAILURE(ERR_DROP_PRIVS);
+            }
+
+            // Finish startup...
+            if (err_pipe[1] != -1) {
+                SIGNAL_SUCCESS();
+            }
+        } /* daemon pid == 0 */
+    } /* first child pid == 0 */
 
     return 0;
 }

--- a/test/oui_test.c
+++ b/test/oui_test.c
@@ -1,0 +1,109 @@
+/*
+ * netmon - simple Linux network monitor
+ *
+ * Copyright: (C) 2019 jawi
+ *   License: Apache License 2.0
+ */
+
+#include <assert.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "oui.h"
+
+#include <CUnit/CUnit.h>
+#include <CUnit/Basic.h>
+
+oui_list_t *oui_list = { 0 };
+
+static int init_suite(void) {
+    oui_list = parse_oui_list("netmon_oui.list");
+
+    return 0;
+}
+
+static int clean_suite(void) {
+    free_oui_list(oui_list);
+
+    return 0;
+}
+
+static void find_no_entry(uint64_t input_oui) {
+    oui_info_t *entry = find_oui(oui_list, input_oui);
+    CU_ASSERT_PTR_NULL(entry);
+}
+
+static void find_oui_entry(uint64_t input_oui, uint64_t expected_oui, const char *expected_vendor) {
+    oui_info_t *entry = find_oui(oui_list, input_oui);
+    CU_ASSERT_PTR_NOT_NULL_FATAL(entry);
+    CU_ASSERT_EQUAL(entry->oui, expected_oui);
+    CU_ASSERT_STRING_EQUAL(entry->manuf, expected_vendor);
+}
+
+static void test_oui_non_matches(void) {
+    CU_ASSERT_PTR_NOT_NULL_FATAL(oui_list);
+
+    struct tst_vec {
+        uint64_t input;
+    } tst_vecs[] = {
+        { 0x0050c3000000 }, // Not allocated
+        { 0x8439bee12345 }, // Not allocated
+        { 0x843b00000000 }, // Not allocated
+    };
+
+    int tst_vec_cnt = sizeof(tst_vecs) / sizeof(struct tst_vec);
+    for (int i = 0; i < tst_vec_cnt; i++) {
+        find_no_entry(tst_vecs[i].input);
+    }
+}
+
+static void test_oui_matches(void) {
+    CU_ASSERT_PTR_NOT_NULL_FATAL(oui_list);
+
+    struct tst_vec {
+        uint64_t input;
+        uint64_t expected_oui;
+        const char *expected_vendor;
+    } tst_vecs[] = {
+        { 0x000000123456, 0x000000000000, "Officially Xerox, but 0:0:0:0:0:0 is more common" },
+        { 0x000000000000, 0x000000000000, "Officially Xerox, but 0:0:0:0:0:0 is more common" },
+        { 0x000001123456, 0x000001000000, "Xerox Corporation" },
+        { 0xfcffaa112233, 0xfcffaa000000, "IEEE Registration Authority" },
+        { 0xfcfc48123456, 0xfcfc48000000, "Apple, Inc." },
+        { 0x001bc5000234, 0x001bc5000000, "Converging Systems Inc." },
+        { 0x001bc5001234, 0x001bc5001000, "OpenRB.com, Direct SIA" },
+        { 0x001bc50c9234, 0x001bc50c9000, "UAB Kitron" },
+        { 0x001bc50ca234, 0x001bc5000000, "IEEE Registration Authority" },
+        { 0x001bc60ca234, 0x001bc6000000, "Strato Rechenzentrum AG" },
+        { 0x843838123456, 0x843838000000, "Samsung Electro-Mechanics(Thailand)" },
+        { 0x8439be012345, 0x8439be000000, "Hino Engineering, Inc" },
+        { 0x0050c2000123, 0x0050c2000000, "T.L.S. Corp." },
+        { 0x0050c2003234, 0x0050c2003000, "Microsoft" },
+        { 0x0050c200a456, 0x0050c200a000, "Tharsys" },
+        { 0x0050c2ffffff, 0x0050c2fff000, "MSR-Solutions GmbH" },
+    };
+
+    int tst_vec_cnt = sizeof(tst_vecs) / sizeof(struct tst_vec);
+    for (int i = 0; i < tst_vec_cnt; i++) {
+        find_oui_entry(tst_vecs[i].input, tst_vecs[i].expected_oui, tst_vecs[i].expected_vendor);
+    }
+}
+
+CU_pSuite create_oui_test_suite(void) {
+    CU_pSuite suite = CU_add_suite("oui test suite", init_suite, clean_suite);
+    if (!suite) {
+        return NULL;
+    }
+
+    if (!CU_add_test(suite, "oui matches", test_oui_matches) ||
+            !CU_add_test(suite, "oui misses", test_oui_non_matches)) {
+        return NULL;
+    }
+
+    return suite;
+}

--- a/test/runner.c
+++ b/test/runner.c
@@ -1,0 +1,35 @@
+/*
+ * netmon - simple Linux network monitor
+ *
+ * Copyright: (C) 2019 jawi
+ *   License: Apache License 2.0
+ */
+
+#include <CUnit/CUnit.h>
+#include <CUnit/Basic.h>
+#include <CUnit/Automated.h>
+
+// oui_test.c
+extern CU_pSuite create_oui_test_suite(void);
+
+int main(void) {
+    // initialize the CUnit test registry
+    if (CU_initialize_registry()) {
+        return CU_get_error();
+    }
+
+    // add a suite to the registry
+    CU_pSuite suite = create_oui_test_suite();
+    if (!suite) {
+        CU_cleanup_registry();
+        return CU_get_error();
+    }
+
+    CU_basic_set_mode(CU_BRM_VERBOSE);
+    CU_basic_run_tests();
+    CU_basic_show_failures(CU_get_failure_list());
+
+    CU_cleanup_registry();
+
+    return CU_get_error();
+}


### PR DESCRIPTION
When a OUI vendor listing is supplied through the configuration, it will be used to lookup vendor names when issuing events. When *no* vendor listing is supplied, no lookups will be performed. The code is inspired on how Wireshark loads and uses vendor lookups.

When receiving SIGUSR2, the configured OUI list is reloaded from disk.

Closes #6 